### PR TITLE
Dependency & maintenance update (#40)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -59,17 +59,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Test webhook
+      - name: Test webhook from test
         uses: joelwmale/webhook-action@master
         if: github.ref == 'refs/heads/test'
         with:
-          url: ${{ secrets.WEBHOOK_URL_TEST }}
+          url: ${{ secrets.WEBHOOK_URL_TEST_FROM_TEST }}
           body: '{}'
-      - name: Prod webhook
+      - name: Prod webhook from main
         uses: joelwmale/webhook-action@master
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         with:
-          url: ${{ secrets.WEBHOOK_URL_PROD }}
+          url: ${{ secrets.WEBHOOK_URL_PROD_FROM_MAIN }}
+          body: '{}'
+      - name: Test webhook from main
+        uses: joelwmale/webhook-action@master
+        if: github.ref == 'refs/heads/main'
+        with:
+          url: ${{ secrets.WEBHOOK_URL_TEST_FROM_MAIN }}
           body: '{}'
 
 #  quayio:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
 	"name": "@natlibfi/melinda-oai-pmh-provider",
-	"version": "2.0.0",
+	"version": "2.0.1-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-oai-pmh-provider",
-			"version": "2.0.0",
+			"version": "2.0.1-alpha.2",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.26.0",
 				"@natlibfi/marc-record": "^9.1.1",
-				"@natlibfi/marc-record-serializers": "^10.1.3",
+				"@natlibfi/marc-record-serializers": "^10.1.4",
 				"@natlibfi/melinda-backend-commons": "^2.3.5",
-				"@natlibfi/melinda-commons": "^13.0.19-alpha.1",
+				"@natlibfi/melinda-commons": "^13.0.19-alpha.2",
 				"@natlibfi/oracledb-aleph": "^6.6.0",
 				"debug": "^4.3.7",
 				"express": "^4.21.1",
 				"http-status": "^1.8.1",
 				"langs": "^2.0.0",
 				"moment": "^2.30.1",
-				"oracledb": "^6.6.0",
+				"oracledb": "^6.7.0",
 				"uuid": "^10.0.0",
 				"xml2js": "^0.6.2"
 			},
@@ -32,9 +32,9 @@
 				"@babel/preset-env": "^7.26.0",
 				"@babel/register": "^7.25.9",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
-				"@natlibfi/fixugen": "^2.0.10",
+				"@natlibfi/fixugen": "^2.0.12",
 				"@natlibfi/fixugen-http-server": "^1.1.16",
-				"@natlibfi/fixura": "^3.0.10",
+				"@natlibfi/fixura": "^3.0.11",
 				"@natlibfi/oracledb-mock": "^1.0.3",
 				"babel-plugin-istanbul": "^7.0.0",
 				"babel-plugin-rewire": "^1.2.0",
@@ -270,9 +270,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-			"integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+			"integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2013,9 +2013,9 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.10.tgz",
-			"integrity": "sha512-GYV9kU2RbG7a7iIM/3j6FITp9AnSquN1eHbwS3m3DPskmw92TXZiWPdzwvPprqHFhZdtlkjU34esPsvH2FMiow==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.12.tgz",
+			"integrity": "sha512-r1H5JPnMVynWtAeEjBZl6sRxog+17Eiv7dkfXtns/Cqxyk1SJkLA8i22ZtNcYFqscuTG/PTTG3dGbyFtzCMrew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2038,9 +2038,9 @@
 			}
 		},
 		"node_modules/@natlibfi/fixura": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.10.tgz",
-			"integrity": "sha512-e988BZI6rcSVPTiYtTzUG3U/U8N2Ui9phOLIFV3SwY1JgEpBRThJMILEISNHo7oME1CZ8rmCHkhNmOvRn4/7Jg==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.11.tgz",
+			"integrity": "sha512-5D/nWcjtobH9zERwLt53ELgLMktgdV1Layly8YpyMfmsbiJtRqSiFSfdNKuo+9dvqMI5zHXyKy+X0xxbC+L+XA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2064,14 +2064,14 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "10.1.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.3.tgz",
-			"integrity": "sha512-dDBWpRpKHCldl+v94/xB0/gfVxED09wQ6/Bt9jbB9F9OQgnjHpFRxkBUmENbf2g1PN8giYv5DAYKqTeFPoakpg==",
+			"version": "10.1.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.1.4.tgz",
+			"integrity": "sha512-zeF/WA8ZWUbJBQBlN9WhHIIvYH+cCQIsW5Plhm8TBAjNFTrYxqujxsb2jGWDjJ/l0G8e/5BzikuizRAUu8o4UQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^9.1.1",
 				"@xmldom/xmldom": "^0.9.5",
-				"stream-json": "^1.8.0",
+				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
 				"yargs": "^17.7.2"
 			},
@@ -2163,13 +2163,13 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.15",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.15.tgz",
-			"integrity": "sha512-iCl0qIufgni/RQKS32aEeuZGnxHFDe5x44jRZPuPiZ/YvYXke8RjUqACV6Sj7/0uPbAApowZL5htvm+0FCp3Uw==",
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.16.tgz",
+			"integrity": "sha512-vS/sdiP25kDlnStgU97NeVzyq0fuMV7NuFmJ73HrsOqdq8/n/6h8ABNBmwqn33/BKn4LD3ShglEGweePPGfhug==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.7",
-				"http-status": "^1.7.4",
+				"http-status": "^1.8.1",
 				"node-fetch": "^2.7.0",
 				"xml2js": "^0.6.2"
 			},
@@ -2268,9 +2268,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+			"version": "22.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2487,18 +2487,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.6"
-			}
-		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"license": "MIT",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
 			}
 		},
 		"node_modules/accepts": {
@@ -2788,14 +2776,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.11",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-			"integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+			"integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"@babel/helper-define-polyfill-provider": "^0.6.3",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2817,13 +2805,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
-			"integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+			"integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2"
+				"@babel/helper-define-polyfill-provider": "^0.6.3"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2841,26 +2829,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
 			"license": "MIT"
 		},
 		"node_modules/base64-url": {
@@ -2924,6 +2892,21 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
 		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2985,30 +2968,6 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -3099,9 +3058,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001677",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-			"integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+			"version": "1.0.30001680",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+			"integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3481,9 +3440,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3800,9 +3759,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.51",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.51.tgz",
-			"integrity": "sha512-kKeWV57KSS8jH4alKt/jKnvHPmJgBxXzGUSbMd4eQF+iOsVPl7bz2KUmu6eo80eMP8wVioTfTyTzdMgM15WXNg==",
+			"version": "1.5.63",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.63.tgz",
+			"integrity": "sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3840,9 +3799,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.3",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+			"version": "1.23.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+			"integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3861,7 +3820,7 @@
 				"function.prototype.name": "^1.1.6",
 				"get-intrinsic": "^1.2.4",
 				"get-symbol-description": "^1.0.2",
-				"globalthis": "^1.0.3",
+				"globalthis": "^1.0.4",
 				"gopd": "^1.0.1",
 				"has-property-descriptors": "^1.0.2",
 				"has-proto": "^1.0.3",
@@ -3877,10 +3836,10 @@
 				"is-string": "^1.0.7",
 				"is-typed-array": "^1.1.13",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.13.1",
+				"object-inspect": "^1.13.3",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.5",
-				"regexp.prototype.flags": "^1.5.2",
+				"regexp.prototype.flags": "^1.5.3",
 				"safe-array-concat": "^1.1.2",
 				"safe-regex-test": "^1.0.3",
 				"string.prototype.trim": "^1.2.9",
@@ -4593,24 +4552,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/events": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.x"
-			}
-		},
 		"node_modules/express": {
 			"version": "4.21.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
@@ -4754,6 +4695,21 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4930,9 +4886,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -4953,17 +4909,33 @@
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/form-data": {
@@ -5534,26 +5506,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -6598,9 +6550,9 @@
 			}
 		},
 		"node_modules/logform": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-			"integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "1.6.0",
@@ -6992,9 +6944,9 @@
 			}
 		},
 		"node_modules/nock": {
-			"version": "13.5.5",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
-			"integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
+			"version": "13.5.6",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+			"integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.0",
@@ -7253,36 +7205,6 @@
 				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
 			}
 		},
-		"node_modules/nyc/node_modules/foreground-child": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/nyc/node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/nyc/node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7372,9 +7294,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+			"integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -7484,9 +7406,9 @@
 			}
 		},
 		"node_modules/oracledb": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.6.0.tgz",
-			"integrity": "sha512-T3dx+o3j+tVN53wQyr4yGTmoPHLy+a2V8yb1T2PmWrsj3ZlSt2Yu1BgV2yTDqnmBZYpRi/I3yJXRCOHHD7PiyA==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.7.0.tgz",
+			"integrity": "sha512-rmYYFSB4I4TAQeP7zjmNw0xvAWHjcmReAclTVXBc/v7a1E9YiKma8pybMbrnRZHu7+zFSyzFb8oWjK8gfY/kEw==",
 			"hasInstallScript": true,
 			"license": "(Apache-2.0 OR UPL-1.0)",
 			"engines": {
@@ -7807,19 +7729,10 @@
 			"integrity": "sha512-TE60RpbLfjeQiTH+HcceBpoJ+Gcn+zRLft5IekcU9gmT0bmumhPWMRME/TkXeiUvOgaMH49pGiHttWQFK+XO4A==",
 			"license": "ISC"
 		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
 		"node_modules/process-on-spawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-			"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+			"integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7869,9 +7782,10 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.13.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+			"integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.0.6"
@@ -8531,6 +8445,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/spawn-wrap/node_modules/foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/spawn-wrap/node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8579,9 +8507,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/stream-json": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.0.tgz",
-			"integrity": "sha512-TqnfW7hRTKje7UobBzXZJ2qOEDJvdcSVgVIK/fopC03xINFuFqQs8RVjyDT4ry7TmOo2ueAXwpXXXG4tNgtvoQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+			"integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"stream-chain": "^2.2.5"
@@ -9306,55 +9234,39 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.16.0.tgz",
-			"integrity": "sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+			"integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
 			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
-				"logform": "^2.6.0",
+				"logform": "^2.7.0",
 				"one-time": "^1.0.0",
 				"readable-stream": "^3.4.0",
 				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.7.0"
+				"winston-transport": "^4.9.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.8.0.tgz",
-			"integrity": "sha512-qxSTKswC6llEMZKgCQdaWgDuMJQnhuvF5f2Nk3SNXc4byfQ+voo2mX1Px9dkNOuR8p0KAjfPG29PuYUSIb+vSA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
 			"license": "MIT",
 			"dependencies": {
-				"logform": "^2.6.1",
-				"readable-stream": "^4.5.2",
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport/node_modules/readable-stream": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-oai-pmh-provider.git"
 	},
 	"license": "MIT",
-	"version": "2.0.0",
+	"version": "2.0.1-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -39,16 +39,16 @@
 	"dependencies": {
 		"@babel/runtime": "^7.26.0",
 		"@natlibfi/marc-record": "^9.1.1",
-		"@natlibfi/marc-record-serializers": "^10.1.3",
+		"@natlibfi/marc-record-serializers": "^10.1.4",
 		"@natlibfi/melinda-backend-commons": "^2.3.5",
-		"@natlibfi/melinda-commons": "^13.0.19-alpha.1",
+		"@natlibfi/melinda-commons": "^13.0.19-alpha.2",
 		"@natlibfi/oracledb-aleph": "^6.6.0",
 		"debug": "^4.3.7",
 		"express": "^4.21.1",
 		"http-status": "^1.8.1",
 		"langs": "^2.0.0",
 		"moment": "^2.30.1",
-		"oracledb": "^6.6.0",
+		"oracledb": "^6.7.0",
 		"uuid": "^10.0.0",
 		"xml2js": "^0.6.2"
 	},
@@ -60,9 +60,9 @@
 		"@babel/preset-env": "^7.26.0",
 		"@babel/register": "^7.25.9",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.5",
-		"@natlibfi/fixugen": "^2.0.10",
+		"@natlibfi/fixugen": "^2.0.12",
 		"@natlibfi/fixugen-http-server": "^1.1.16",
-		"@natlibfi/fixura": "^3.0.10",
+		"@natlibfi/fixura": "^3.0.11",
 		"@natlibfi/oracledb-mock": "^1.0.3",
 		"babel-plugin-istanbul": "^7.0.0",
 		"babel-plugin-rewire": "^1.2.0",


### PR DESCRIPTION
* Bump the production-dependencies group across 1 directory with 2 updates (#39)

Bumps the production-dependencies group with 2 updates in the / directory: [@natlibfi/marc-record-serializers](https://github.com/natlibfi/marc-record-serializers) and [oracledb](https://github.com/oracle/node-oracledb).

* Bump the development-dependencies group with 2 updates (#37)

Bumps the development-dependencies group with 2 updates: [@natlibfi/fixugen](https://github.com/natlibfi/fixugen-js) and [@natlibfi/fixura](https://github.com/natlibfi/fixura-js).

* Update webhooks (#36)

* Update deps

* 2.0.1-alpha.2